### PR TITLE
ellison/fix-forced-output-for-python

### DIFF
--- a/python2.7/build/Dockerfile
+++ b/python2.7/build/Dockerfile
@@ -2,6 +2,7 @@ ARG TAG="latest"
 FROM aliyunfc/runtime-python2.7:${TAG}
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update \
     && apt-get install -y apt-utils \

--- a/python2.7/run/agent.sh
+++ b/python2.7/run/agent.sh
@@ -37,7 +37,7 @@ fi
 command=$1
 case ${command} in
     "start")
-        python -W ignore ${DEBUG_OPTIONS} ${FC_SERVER_PATH}/src/server.py -u
+        python -W ignore ${DEBUG_OPTIONS} ${FC_SERVER_PATH}/src/server.py
         ;;
     "help")
         Help

--- a/python3.6/build/Dockerfile
+++ b/python3.6/build/Dockerfile
@@ -2,6 +2,7 @@ ARG TAG="latest"
 FROM aliyunfc/runtime-python3.6:${TAG}
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update \
     && apt-get install -y apt-utils \    

--- a/python3.6/run/agent.sh
+++ b/python3.6/run/agent.sh
@@ -37,7 +37,7 @@ fi
 command=$1
 case ${command} in
     "start")
-        python -W ignore ${DEBUG_OPTIONS} ${FC_SERVER_PATH}/src/server.py -u
+        python -W ignore ${DEBUG_OPTIONS} ${FC_SERVER_PATH}/src/server.py
         ;;
     "help")
         Help


### PR DESCRIPTION
在linux上后台运行python程序stdout会先输出到缓冲区，等缓冲区满或者脚本结束再输出，而stderr不会先输出到缓冲区。
fix https://github.com/alibaba/funcraft/issues/373