### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/custom/base/Dockerfile
+++ b/custom/base/Dockerfile
@@ -7,11 +7,11 @@ RUN echo "deb http://deb.debian.org/debian/ stretch main contrib non-free" > /et
     && echo "deb http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list \
     && echo "deb-src http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         curl \
         wget \
         unzip \
-    --no-install-recommends && rm -r /var/lib/apt/lists/*
+    && rm -r /var/lib/apt/lists/*
 
 RUN wget https://nodejs.org/download/release/v10.16.2/node-v10.16.2-linux-x64.tar.gz -O /tmp/node-v10.16.2-linux-x64.tar.gz \
     && cd /tmp && tar -zxvf /tmp/node-v10.16.2-linux-x64.tar.gz \
@@ -23,18 +23,18 @@ RUN wget https://nodejs.org/download/release/v10.16.2/node-v10.16.2-linux-x64.ta
     && rm -rf /tmp/node-v10.16.2-linux-x64*
 
 # https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-debian-9
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         fonts-wqy-zenhei=0.9.45-6 \
         fonts-wqy-microhei=0.2.0-beta-2 \
         xfonts-wqy=1.0.0~rc1-6 \
-    --no-install-recommends && rm -r /var/lib/apt/lists/*
+    && rm -r /var/lib/apt/lists/*
 
 # https://github.com/puckel/docker-airflow/issues/182
 RUN mkdir -p /usr/share/man/man1
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         openjdk-8-jdk \
         build-essential=12.3 \
-    --no-install-recommends && rm -r /var/lib/apt/lists/*
+    && rm -r /var/lib/apt/lists/*
 
 
 # Generate usernames

--- a/custom/build/Dockerfile
+++ b/custom/build/Dockerfile
@@ -3,7 +3,7 @@ FROM aliyunfc/runtime-custom:${TAG}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y apt-utils \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         dialog \
         vim \ 
         cmake \

--- a/custom/run/Dockerfile
+++ b/custom/run/Dockerfile
@@ -12,7 +12,7 @@ RUN GOARCH=amd64 GOOS=linux go build -o mock main.go
 FROM aliyunfc/runtime-custom:${TAG}
 
 RUN apt-get update \
-  && apt-get install -y procps --no-install-recommends \
+  && apt-get --no-install-recommends  install -y apt-utils ca-certificates procps \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /code/mock /var/fc/runtime/custom/mock

--- a/dotnetcore2.1/base/Dockerfile
+++ b/dotnetcore2.1/base/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER alibaba-serverless-fc
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
@@ -20,7 +20,7 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
        libc6-dev=2.24-11+deb9u4 \
        libgdiplus=4.2-1+b1  \
     && rm -rf /var/lib/apt/lists/

--- a/dotnetcore2.1/build/Dockerfile
+++ b/dotnetcore2.1/build/Dockerfile
@@ -4,7 +4,7 @@ FROM aliyunfc/runtime-dotnetcore2.1:${TAG}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y apt-utils \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         dialog \
         vim \ 
         cmake \

--- a/dotnetcore2.1/run/Dockerfile
+++ b/dotnetcore2.1/run/Dockerfile
@@ -16,7 +16,7 @@ RUN rm -rf /var/runtime /var/lang && \
   rm -rf /var/fc/runtime/*/var/log/*
 
 RUN apt-get update \
-  && apt-get install -y procps unzip --no-install-recommends \
+  && apt-get --no-install-recommends  install -y apt-utils ca-certificates procps unzip \
   && rm -rf /var/lib/apt/lists/*
 
 COPY dotnetcore2.1/run/agent.sh /var/fc/runtime/dotnetcore2.1/agent.sh

--- a/java8/base/Dockerfile
+++ b/java8/base/Dockerfile
@@ -30,7 +30,7 @@ COPY commons/debian-stretch-sources.list /etc/apt/sources.list
 
 # Install common libraries
 RUN apt-get -o Acquire::Check-Valid-Until=false update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         imagemagick \
         make=4.1-9.1 \
         libopencv-dev=2.4.9.1+dfsg1-2 \

--- a/java8/build/Dockerfile
+++ b/java8/build/Dockerfile
@@ -3,7 +3,7 @@ FROM aliyunfc/runtime-java8:${TAG}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -o Acquire::Check-Valid-Until=false update \
-    && apt-get install -y apt-utils \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         dialog \
         vim \ 
         cmake \

--- a/nodejs10/base/Dockerfile
+++ b/nodejs10/base/Dockerfile
@@ -40,7 +40,7 @@ RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak
 COPY commons/debian-jessie-sources.list /etc/apt/sources.list
 
 # Install common libraries
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         cmake \
         imagemagick=8:6.8.9.9-5+deb8u15 \
         libopencv-dev=2.4.9.1+dfsg-1+deb8u2 \

--- a/nodejs10/build/Dockerfile
+++ b/nodejs10/build/Dockerfile
@@ -2,7 +2,7 @@ ARG TAG="latest"
 FROM aliyunfc/runtime-nodejs10:${TAG}
 
 RUN apt-get update \
-    && apt-get install -y apt-utils \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         dialog \
         vim \ 
         cmake \

--- a/nodejs6/base/Dockerfile
+++ b/nodejs6/base/Dockerfile
@@ -27,7 +27,7 @@ RUN npm install \
 
 # Install common libraries
 RUN apt-get update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         imagemagick \
         libopencv-dev \
         fonts-wqy-zenhei=0.9.45-6 \

--- a/nodejs6/build/Dockerfile
+++ b/nodejs6/build/Dockerfile
@@ -4,7 +4,7 @@ FROM aliyunfc/runtime-nodejs6:${TAG}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y apt-utils \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         dialog \
         vim \
         cmake \

--- a/nodejs8/base/Dockerfile
+++ b/nodejs8/base/Dockerfile
@@ -25,7 +25,7 @@ RUN npm install \
 
 # Install common libraries
 RUN apt-get update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         imagemagick  \
         libopencv-dev \
         fonts-wqy-zenhei=0.9.45-6 \

--- a/nodejs8/build/Dockerfile
+++ b/nodejs8/build/Dockerfile
@@ -3,7 +3,7 @@ FROM aliyunfc/runtime-nodejs8:${TAG}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y apt-utils \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         dialog \
         vim \ 
         cmake \

--- a/php7.2/base/Dockerfile
+++ b/php7.2/base/Dockerfile
@@ -41,7 +41,7 @@ COPY commons/debian-jessie-sources.list /etc/apt/sources.list
 
 RUN /bin/sh -c 'curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer'
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         git \
         wget \
         unzip\
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y \
         libmagickwand-dev \
         libmagickcore-dev \
         libmemcached-dev=1.0.18-4 \
-    --no-install-recommends && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # phpunit and xdebug
 RUN wget -O phpunit https://phar.phpunit.de/phpunit-7.2.7.phar

--- a/php7.2/build/Dockerfile
+++ b/php7.2/build/Dockerfile
@@ -4,7 +4,7 @@ FROM aliyunfc/runtime-php7.2:${TAG}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y apt-utils \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         dialog \
         vim \
         cmake \

--- a/python2.7/base/Dockerfile
+++ b/python2.7/base/Dockerfile
@@ -23,7 +23,7 @@ RUN pip install coverage
 # Install common libraries
 # imagemagick=8:6.9.7.4+dfsg-11+deb9u3 already exist, ignore
 RUN apt-get update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         imagemagick \
         libopencv-dev \
         fonts-wqy-zenhei=0.9.45-6 \

--- a/python2.7/build/Dockerfile
+++ b/python2.7/build/Dockerfile
@@ -4,7 +4,7 @@ FROM aliyunfc/runtime-python2.7:${TAG}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y apt-utils \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         dialog \
         vim \ 
         cmake \

--- a/python3.6/base/Dockerfile
+++ b/python3.6/base/Dockerfile
@@ -23,7 +23,7 @@ RUN pip install coverage
 # Install common libraries
 # imagemagick=8:6.9.7.4+dfsg-11+deb9u3 already installed
 RUN apt-get update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         imagemagick \
         libopencv-dev=2.4.9.1+dfsg-1+deb8u2 \
         fonts-wqy-zenhei=0.9.45-6 \

--- a/python3.6/build/Dockerfile
+++ b/python3.6/build/Dockerfile
@@ -4,7 +4,7 @@ FROM aliyunfc/runtime-python3.6:${TAG}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y apt-utils \    
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \    
         dialog \
         vim \ 
         cmake \


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is

1.  Slow and in log it is showing because "apt-utils" not installed

2. to avoid build to exits with error without having certificate

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>