### PR TITLE
feat: add nodejs12 runtime

### DIFF
--- a/nodejs12/base/Dockerfile
+++ b/nodejs12/base/Dockerfile
@@ -1,0 +1,81 @@
+FROM node:12.18.0-stretch
+
+MAINTAINER alibaba-serverless-fc
+
+# Environment variables.
+ENV FC_SERVER_PATH=/var/fc/runtime/nodejs12 \
+    NODE_PATH=/usr/local/lib/node_modules \
+    PATH=${FC_SERVER_PATH}/node_modules/.bin:${PATH}
+
+# Create directory.
+RUN mkdir -p ${FC_SERVER_PATH}
+
+ARG FC_RUNTIME_PATH=/var/fc/runtime
+
+# Environment variables can be overwritten by running
+# $ docker run --env <key>=<value>
+ENV FC_SERVER_PORT=9000 \
+    FC_SERVER_CAM_PORT=10080 \
+    FC_SERVER_LOG_PATH=${FC_SERVER_PATH}/var/log \
+    FC_SERVER_LOG_LEVEL=info \
+    FC_FUNC_CODE_PATH=/code/ \
+    FC_FUNC_LOG_PATH=/var/log/fc/
+
+ENV LD_LIBRARY_PATH=${FC_FUNC_CODE_PATH}:${FC_FUNC_CODE_PATH}/lib
+
+# Create directories.
+RUN mkdir -p \
+    ${FC_SERVER_LOG_PATH}
+
+RUN chmod 777 ${FC_SERVER_LOG_PATH}
+RUN chmod -R 777 /tmp/
+
+# Change work directory.
+WORKDIR ${FC_SERVER_PATH}
+
+# Expose the port number.
+EXPOSE ${FC_SERVER_PORT}
+
+RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak
+COPY commons/debian-jessie-sources.list /etc/apt/sources.list
+
+# Install common libraries
+RUN apt-get update && apt-get --no-install-recommends install -y \
+        cmake \
+        imagemagick=8:6.8.9.9-5+deb8u15 \
+        libopencv-dev=2.4.9.1+dfsg-1+deb8u2 \
+        fonts-wqy-zenhei=0.9.45-6 \
+        fonts-wqy-microhei=0.2.0-beta-2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Suppress opencv error: "libdc1394 error: Failed to initialize libdc1394"
+RUN ln /dev/null /dev/raw1394
+
+# Install thrid party libraries for user function.
+RUN npm install --global --unsafe-perm \
+        --registry http://registry.npm.taobao.org \
+        co@4.6.0 \
+        gm@1.23.0 \
+        ali-oss@4.10.1 \
+        aliyun-sdk@1.11.10 \
+        @alicloud/fc@1.2.2 \
+        tablestore@4.2.0\
+        @alicloud/fc2@2.1.0 \
+        opencv@6.2.0 \
+        body@5.1.0 \
+        raw-body@2.3.2 \
+        ali-mns@2.6.5 \
+        @alicloud/pop-core@1.7.0
+
+RUN npm cache clean --force
+
+# Generate usernames
+RUN for i in $(seq 10000 10999); do \
+        echo "user$i:x:$i:$i::/tmp:/usr/sbin/nologin" >> /etc/passwd; \
+    done
+
+# Change work directory.
+WORKDIR ${FC_FUNC_CODE_PATH}
+
+# Start a shell by default
+CMD ["bash"]

--- a/nodejs12/build/Dockerfile
+++ b/nodejs12/build/Dockerfile
@@ -1,0 +1,47 @@
+ARG TAG="latest"
+FROM aliyunfc/runtime-nodejs12:${TAG}
+
+RUN mkdir -p /mnt/auto
+RUN apt-get update \
+    && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
+        dialog \
+        vim \
+        cmake \
+        zip \
+        unzip \
+        clang \
+        build-essential \
+        libgmp3-dev \
+        python2.7-dev \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "ALL ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+ARG FUN_VERSION
+ARG FCLI_VERSION
+ARG FUN_INSTALL_VERSION
+
+RUN curl -s https://gosspublic.alicdn.com/fcli/fcli-${FCLI_VERSION}-linux-amd64.zip > fcli.zip \
+    && unzip -o fcli.zip -d /usr/local/bin/ \
+    && rm fcli.zip
+
+RUN curl -s https://gosspublic.alicdn.com/fun/fun-${FUN_VERSION}-linux.zip > fun.zip \
+    && unzip -o fun.zip -d /usr/local/bin/ \
+    && rm fun.zip \
+    && mv /usr/local/bin/fun-v* /usr/local/bin/fun
+
+RUN curl -s https://gosspublic.alicdn.com/fun-install/fun-install-${FUN_INSTALL_VERSION}-linux-64.zip > fun-install.zip \
+    && unzip -o fun-install.zip -d /usr/local/bin/ \
+    && rm fun-install.zip \
+    && mv /usr/local/bin/fun-install-v* /usr/local/bin/fun-install
+
+RUN mv /usr/bin/update-alternatives  /usr/bin/update-alternatives-origin \
+ && ((test -f /usr/bin/pycompile && mv /usr/bin/pycompile  /usr/bin/pycompile-origin) || true)
+
+COPY commons/update-alternatives  /usr/bin/
+COPY commons/pycompile  /usr/bin/
+
+WORKDIR /code
+
+CMD ["npm", "rebuild"]

--- a/nodejs12/run/Dockerfile
+++ b/nodejs12/run/Dockerfile
@@ -1,0 +1,11 @@
+ARG TAG="latest"
+FROM aliyunfc/runtime-nodejs12:${TAG}
+
+RUN rm -rf /var/runtime /var/lang && \
+  curl https://my-fc-testt.oss-cn-shanghai.aliyuncs.com/nodejs12.tgz | tar -zx -C / && \
+  rm -rf /var/fc/runtime/*/var/log/*
+
+COPY commons/function-compute-mock.sh /var/fc/runtime/nodejs12/mock
+COPY commons/nodejs-agent.sh /var/fc/runtime/nodejs12/agent.sh
+
+ENTRYPOINT ["/var/fc/runtime/nodejs12/mock"]


### PR DESCRIPTION
文件结构来自于 nodejs 10 运行时.

可能需要审查的内容:

1. node 镜像的版本
1. 通过 apt 安装的依赖的版本
1. 通过 npm 安装的依赖的版本
1. 通过 curl 下载的文件是否真实存在
1. Dockerfile 中的各个相对路径是否可用

这个 PR 是为 https://github.com/alibaba/funcraft/pull/931 做准备的.

