### PR TITLE
fix: 修复Java镜像的log4j版本

### DIFF
--- a/java11/base/pom.xml
+++ b/java11/base/pom.xml
@@ -106,12 +106,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.8.2</version>
+      <version>2.17.1</version>
     </dependency>
 
     <!-- embedded jetty -->

--- a/java8/base/pom.xml
+++ b/java8/base/pom.xml
@@ -106,12 +106,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.8.2</version>
+      <version>2.17.1</version>
     </dependency>
 
     <!-- embedded jetty -->


### PR DESCRIPTION
升级java基础镜像中log4j版本到2.8.2